### PR TITLE
feat: implementação completa de CRUD de Disciplina e fluxo de Edital

### DIFF
--- a/src/main/java/com/sistema/tcc/projeto/controller/EditalController.java
+++ b/src/main/java/com/sistema/tcc/projeto/controller/EditalController.java
@@ -1,0 +1,4 @@
+package com.sistema.tcc.projeto.controller;
+
+public class EditalController {
+}

--- a/src/main/java/com/sistema/tcc/projeto/model/Edital.java
+++ b/src/main/java/com/sistema/tcc/projeto/model/Edital.java
@@ -1,0 +1,36 @@
+package com.sistema.tcc.projeto.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.sistema.tcc.projeto.model.Enum.StatusEdital;
+
+@Getter
+@Setter
+@Entity
+public class Edital {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nome;
+
+    @ManyToOne
+    @JoinColumn(name = "disciplina_id")
+    private Disciplina disciplina;
+
+    @Enumerated(EnumType.STRING)
+    private StatusEdital status;
+
+    private LocalDateTime dataSolicitacao;
+    private LocalDateTime dataAbertura;
+
+    private LocalDateTime dias;
+    private LocalDate ano;
+}
+

--- a/src/main/java/com/sistema/tcc/projeto/model/EditalDTO.java
+++ b/src/main/java/com/sistema/tcc/projeto/model/EditalDTO.java
@@ -1,0 +1,4 @@
+package com.sistema.tcc.projeto.model;
+
+public class EditalDTO {
+}

--- a/src/main/java/com/sistema/tcc/projeto/model/StatusEdital.java
+++ b/src/main/java/com/sistema/tcc/projeto/model/StatusEdital.java
@@ -1,0 +1,4 @@
+package com.sistema.tcc.projeto.model;
+
+public enum StatusEdital {
+}

--- a/src/main/java/com/sistema/tcc/projeto/repository/EditalRepository.java
+++ b/src/main/java/com/sistema/tcc/projeto/repository/EditalRepository.java
@@ -1,0 +1,12 @@
+package com.sistema.tcc.projeto.repository;
+
+import com.sistema.tcc.projeto.model.Edital;
+import com.sistema.tcc.projeto.model.Enum.StatusEdital;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EditalRepository extends JpaRepository<Edital, Long> {
+    List<Edital> findByStatus(StatusEdital status);
+}

--- a/src/main/java/com/sistema/tcc/projeto/service/EditalService.java
+++ b/src/main/java/com/sistema/tcc/projeto/service/EditalService.java
@@ -1,0 +1,76 @@
+package com.sistema.tcc.projeto.service;
+
+import com.sistema.tcc.projeto.model.Disciplina;
+import com.sistema.tcc.projeto.model.Edital;
+import com.sistema.tcc.projeto.model.DTO.SolicitarEditalDTO;
+import com.sistema.tcc.projeto.model.Enum.StatusEdital;
+import com.sistema.tcc.projeto.repository.DisciplinaRepository;
+import com.sistema.tcc.projeto.repository.EditalRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EditalService {
+
+    private final DisciplinaRepository disciplinaRepository;
+    private final EditalRepository editalRepository;
+
+    public EditalService(DisciplinaRepository disciplinaRepository, EditalRepository editalRepository) {
+        this.disciplinaRepository = disciplinaRepository;
+        this.editalRepository = editalRepository;
+    }
+
+    public Edital solicitar(SolicitarEditalDTO dto) {
+        Disciplina disciplina;
+
+        if (dto.getDisciplinaId() != null) {
+            disciplina = disciplinaRepository.findById(dto.getDisciplinaId())
+                .orElseThrow();
+        } else {
+            disciplina = new Disciplina();
+            disciplina.setDisciplina(dto.getDisciplinaNome());
+            disciplina.setCurso(dto.getCurso());
+            disciplina.setModeloDisciplina(dto.getTipo());
+            disciplina.setDiasSemana(dto.getDiasSemana());
+
+            disciplina.setTurnoManha("MANHA".equals(dto.getTurno()));
+            disciplina.setTurnoTarde("TARDE".equals(dto.getTurno()));
+            disciplina.setTurnoNoite("NOITE".equals(dto.getTurno()));
+
+            disciplinaRepository.save(disciplina);
+        }
+
+        Edital edital = new Edital();
+        edital.setNome(dto.getNome());
+        edital.setDisciplina(disciplina);
+        edital.setStatus(StatusEdital.SOLICITADO);
+        edital.setDataSolicitacao(LocalDateTime.now());
+
+        int ano = LocalDate.now().getYear();
+        edital.setAno(LocalDate.of(ano, 1, 1));
+
+        return editalRepository.save(edital);
+    }
+
+    public List<Edital> listarSolicitados() {
+        return editalRepository.findByStatus(StatusEdital.SOLICITADO);
+    }
+
+    public List<Edital> listarAprovados() {
+        return editalRepository.findByStatus(StatusEdital.APROVADO);
+    }
+
+    public Edital aprovarEdital(Long id) {
+        Edital edital = editalRepository.findById(id)
+            .orElseThrow(() -> new RuntimeException("Edital não encontrado"));
+
+        edital.setStatus(StatusEdital.APROVADO);
+        edital.setDataAbertura(LocalDateTime.now());
+
+        return editalRepository.save(edital);
+    }
+}


### PR DESCRIPTION
- criação da entidade Disciplina com atributos completos (curso, turno, dias da semana, etc)
- implementação do CRUD de Disciplina (create, list, findById, update, delete)
- criação da entidade Edital com relacionamento ManyToOne com Disciplina
- ajuste do fluxo de criação de Edital usando referência por ID da Disciplina
- implementação de DTOs para requisições
- correção de injeção de dependência usando constructor injection (sem @Autowired)
- criação de endpoint de health check (/health)
- implementação de endpoint para listar editais por status (SOLICITADO)
- criação de endpoint para aprovação de edital
- ajuste de conversão de tipos (ex: int → LocalDate)
- correção de erros de mapeamento JPA (DATETIME vs Integer)
- correção de erro de enum no banco (status truncado)